### PR TITLE
fix: fix SecurityScheme oauth/oidc validation

### DIFF
--- a/openapi/OpenApi.pkl
+++ b/openapi/OpenApi.pkl
@@ -187,8 +187,8 @@ class SecurityScheme {
   `in`: ("query" | "header" | "cookie")?((this != null).xor(type != "apiKey"))
   scheme: ("basic" | "bearer" | "digest" | "dpop" | "hoba" | "mutual" | "negotiate" | "oauth" | "privatetoken" | "scram-sha-1" | "scram-sha-256" | "vapid")?((this != null).xor(type != "http"))
   bearerFormat: String?(this == null || (type == "http" && scheme == "bearer"))
-  flows: OAuthFlows?((this == null).xor(type != "oauth2"))
-  openIdConnectUrl: String?((this == null).xor(type != "openIdConnect"))
+  flows: OAuthFlows?((this != null).xor(type != "oauth2"))
+  openIdConnectUrl: String?((this != null).xor(type != "openIdConnect"))
 }
 
 class OAuthFlows {


### PR DESCRIPTION
Same as #4, missed the xors for `flows` and `openIdConnectUrl`.